### PR TITLE
Return Window Controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,3 @@
-# Firefox Lumina
-A userstylesheet dark theme for Firefox, designed for using with Tree Style Tabs.
+Returned WIndow Controls
 
-> Wallpaper by [Glenn Carstens-Peters](https://unsplash.com/@glenncarstenspeters)
-
-![screenshot](screenshot.png)
-## Design Aspects
-- The browser theme should not distract the user from the content of the page that they are viewing.
-- The browser theme should mix elegantly with modern styles used by most sites.
-- Vertical Tabs >>> Horizontal Tabs
-- Rounded elements look better
-
-## Installation
-1. Clone the repo
-```
-git clone https://github.com/mastermach50/firefox-lumina.git --depth 1
-```
-2. Copy the `chrome` folder into your firefox user profile folder
-> Remember to backup your current chrome folder if it exists
-
-3. Go to `about:config` of firefox
-
-4. Make sure that `toolkit.legacyUserProfileCustomizations.stylesheets` is enabled
-
-5. Install and enable the __lumina theme__ from [here](https://addons.mozilla.org/en-US/firefox/addon/lumina-ma3/)
-
-6. Install and enable __Tree Style Tab__ from [here](https://addons.mozilla.org/en-US/firefox/addon/tree-style-tab/)
-
-7. Set `Website Appearence` to `Dark` in `about:preferences#general`.
-
-5. Restart the browser
-
-> Feel free to create an issue if something is not looking right
+[screenshot]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,33 @@
-Returned WIndow Controls
+# Firefox Lumina
+A userstylesheet dark theme for Firefox, designed for using with Tree Style Tabs.
 
-[screenshot]
+> Wallpaper by [Glenn Carstens-Peters](https://unsplash.com/@glenncarstenspeters)
 
-See:
-https://github.com/soulhotel/firefox-lumina/blob/0b86dbcd8dfe0ce8f4dda5385560ed5a31e53b00/chrome/window-controls.css#L1-L73
+![screenshot](screenshot.png)
+## Design Aspects
+- The browser theme should not distract the user from the content of the page that they are viewing.
+- The browser theme should mix elegantly with modern styles used by most sites.
+- Vertical Tabs >>> Horizontal Tabs
+- Rounded elements look better
+
+## Installation
+1. Clone the repo
+```
+git clone https://github.com/mastermach50/firefox-lumina.git --depth 1
+```
+2. Copy the `chrome` folder into your firefox user profile folder
+> Remember to backup your current chrome folder if it exists
+
+3. Go to `about:config` of firefox
+
+4. Make sure that `toolkit.legacyUserProfileCustomizations.stylesheets` is enabled
+
+5. Install and enable the __lumina theme__ from [here](https://addons.mozilla.org/en-US/firefox/addon/lumina-ma3/)
+
+6. Install and enable __Tree Style Tab__ from [here](https://addons.mozilla.org/en-US/firefox/addon/tree-style-tab/)
+
+7. Set `Website Appearence` to `Dark` in `about:preferences#general`.
+
+5. Restart the browser
+
+> Feel free to create an issue if something is not looking right

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 Returned WIndow Controls
 
 [screenshot]
+
+See:
+https://github.com/soulhotel/firefox-lumina/blob/0b86dbcd8dfe0ce8f4dda5385560ed5a31e53b00/chrome/window-controls.css#L1-L73

--- a/chrome/userChrome.css
+++ b/chrome/userChrome.css
@@ -1,4 +1,5 @@
 @import "./colors.css";
+@import "./window-controls.css";
 
 #titlebar {
   display: none;

--- a/chrome/window-controls.css
+++ b/chrome/window-controls.css
@@ -20,7 +20,7 @@ macos layout
     --wc-top: 4.2px;
     --wc-left: 3px;
     --wc-right: 2px;
-    --navbar-margin: 103px;
+    --navbar-margin: 93px;
     --mb-height: 20px;
 }
 
@@ -34,6 +34,7 @@ macos layout
 
 #titlebar { -moz-appearance: none !important; --tabs-navbar-shadow-size: 0px; }
 #navigator-toolbox { background: var(--toolbar-bgcolor) !important; }
+.browser-toolbar { &:not(.titlebar-color) { background-color: initial !important; }}
 #navigator-toolbox > div{ display: contents }
 .global-notificationbox, #tab-notification-deck{order: 2;}
 #TabsToolbar .titlebar-spacer{ display: none; }
@@ -63,8 +64,8 @@ toolbox#navigator-toolbox > toolbar#nav-bar.browser-toolbar{ animation: none; }
 /* adjust window control total button size to match toolbar buttons (30px). */
 @media (-moz-platform: windows) {
     .titlebar-buttonbox .titlebar-button {
-        padding: 11px 11px !important;
-        border-radius: 5px !important;
+        padding: 10px 10px !important;
+        border-radius: 4px !important;
     }
 }
 

--- a/chrome/window-controls.css
+++ b/chrome/window-controls.css
@@ -2,67 +2,65 @@
 
 /* Index [ctrl+f to find a section]
 
+default positioning of window controls
 baseline modifications
 to return the title bar buttons
 adjust nav bar margin
 total button size
 (optional) flip button order
 when in fullscreen mode
+menubar adjustments
 macos layout
 
-/*-------------------------------------------------------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+
+/* default positioning of window controls */
+
+:root, * {
+    --wc-top: 4.2px;
+    --wc-left: 3px;
+    --wc-right: 2px;
+    --navbar-margin: 98px;
+    --mb-height: 20px;
+}
+
+/*--------------------------------------------------------------------------------------*/
 
 /* baseline modifications */
 
-#navigator-toolbox {
-  background: var(--toolbar-bgcolor) !important;
-}
-
+#titlebar { order: 2; }
+#titlebar { display: initial !important; }
 #TabsToolbar { display: none !important; }
 
-#titlebar { display: initial !important; }
-
-#titlebar {
-    order: 2;
-    -moz-appearance: none !important;
-    --tabs-navbar-shadow-size: 0px;
-}
-
+#titlebar { -moz-appearance: none !important; --tabs-navbar-shadow-size: 0px; }
+#navigator-toolbox { background: var(--toolbar-bgcolor) !important; }
 #navigator-toolbox > div{ display: contents }
-
 .global-notificationbox, #tab-notification-deck{order: 2;}
-
 #TabsToolbar .titlebar-spacer{ display: none; }
-
 #navigator-toolbox::after{ display: none !important; }
-
 toolbox#navigator-toolbox > toolbar#nav-bar.browser-toolbar{ animation: none; }
-
 #navigator-toolbox:hover #TabsToolbar{ animation: slidein ease-out 48ms 1; }
-
 #navigator-toolbox:not(:-moz-lwtheme){ background-color: -moz-dialog; }
-
 
 /*--------------------------------------------------------------------------------------*/
 
 /* to return the title bar buttons */
-
 :root[tabsintitlebar] .titlebar-buttonbox{
     position: fixed !important;
     display: flex !important;
     z-index: 2 !important;
-    top: 4.2px !important;
-    right: 2px !important; /* or use 'left' to simulate macos positioning */
+    top: var(--wc-top) !important;
+    right: var(--wc-right) !important;
+    /* you can use 'left' instead of 'right' to simulate macos positioning */
 }
 
-/* to simulate toolbar buttons size and positioning, while keeping the window controls to the far end of the bar */
-
-/* adjust nav bar margin */
+/* adjust nav bar margin to give the window controls area to sit */
 #nav-bar {
-    margin-right: 98px; /* margin-left if you have it on left side*/
+    margin-right: var(--navbar-margin);
+    /* margin-left if you have it on left side*/
 } 
 
-/* 30px total button size to match toolbar buttons. */
+/* adjust window control total button size to match toolbar buttons (30px). */
 @media (-moz-platform: windows) {
     .titlebar-buttonbox .titlebar-button {
         padding: 11px 11px !important;
@@ -70,31 +68,69 @@ toolbox#navigator-toolbox > toolbar#nav-bar.browser-toolbar{ animation: none; }
     }
 }
 
-/* (optional) flip button order
-.titlebar-buttonbox-container{ direction: rtl; } */
+/* (optional) flip button order */
+/*.titlebar-buttonbox-container{ direction: rtl; } */
 
-/* when in fullscreen mode, and the navigation bar isnt hovered, workaround for fixed title bar buttons */
+/*--------------------------------------------------------------------------------------*/
+
+/* when in fullscreen mode, and the navigation bar isnt visible, remove window controls */
 
 :root[inFullscreen="true"] #navigator-toolbox:not(:hover) .titlebar-buttonbox {
     display: none !important;
 }
 
+/*--------------------------------------------------------------------------------------*/
+
+/* menubar adjustments
+
+the titlebar must have an order of 2 - to keep window controls in one-line navigation bar themes.
+But this means, the menubar will be rearranged to sit under the navigation bar.
+The solution to this is to set the titlebar order back to 0 (default), when the menu bar is active.
+This will require repositioning the window controls, to keep them at the same height as the navigation bar as well. 
+
+reference:
+when the menubar is toggled on it uses the following selectors: #toolbar-menubar[autohide="true"]:not([inactive="true"])
+when the menubar is triggered with 'ALT' it uses this selector: #titlebar #toolbar-menubar[autohide="false"]
+*/
+
+/* the menu bar defaults to 20px, this ensures that it remains that height. */
+
+:root[tabsintitlebar] { & #toolbar-menubar[autohide="true"] { max-height: var(--mb-height) !important; } }
+
+/* to have the menu bar display at the very top of the UI */
+
+#titlebar:has([autohide="false"]),
+#titlebar:has([autohide="true"]:not([inactive="true"])) {
+    order: 0;
+}
+
+/* adjust the window controls positioning - to match the navigation bar displacement */
+
+#titlebar:has([autohide="false"]),
+#titlebar:has([autohide="true"]:not([inactive="true"])) {
+    & .titlebar-buttonbox { 
+        top: calc(var(--wc-top) + var(--mb-height)) !important;
+    }
+}
 
 /*--------------------------------------------------------------------------------------*/
 
 /* macos layout */
 
 @media (-moz-os-version: macos), (-moz-platform: macos) {
+    :root, * {
+        --wc-top: 12px;
+        --wc-left: 3px;
+        --wc-right: unset;
+        --navbar-margin: 98px;
+        --mb-height: 20px;
+    }
+    
     #nav-bar {
-        margin-left: 84px !important;
+        margin-left: var(--navbar-margin) !important;
         margin-right: 0px !important;
     }    
     
-    :root[tabsintitlebar] .titlebar-buttonbox {
-        top: 12px !important;
-        right: unset !important;
-        left: 3px !important;
-    }
     toolbar {
         min-height: 0px !important;
     }

--- a/chrome/window-controls.css
+++ b/chrome/window-controls.css
@@ -1,7 +1,7 @@
 @namespace xul url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
 #navigator-toolbox {
-  background: var(--lumina-bg-color-primary) !important;
+  background: var(--toolbar-bgcolor) !important;
 }
 #TabsToolbar {
   display: none !important;

--- a/chrome/window-controls.css
+++ b/chrome/window-controls.css
@@ -45,13 +45,14 @@ toolbox#navigator-toolbox > toolbar#nav-bar.browser-toolbar{ animation: none; }
 
 /* adjust nav bar margin for fixed button */
 #nav-bar {
-    margin-right: 96px;
+    margin-right: 98px;
 } /* margin-left if you have it on left side*/
 
 /* 30px total button size to match toolbar buttons. */
 @media (-moz-platform: windows) {
     .titlebar-buttonbox .titlebar-button {
         padding: 11px 11px !important;
+        border-radius: 5px !important;
     }
 }
 

--- a/chrome/window-controls.css
+++ b/chrome/window-controls.css
@@ -1,7 +1,18 @@
 @namespace xul url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
+/* Index [ctrl+f to find a section]
+
+baseline modifications
+to return the title bar buttons
+adjust nav bar margin
+total button size
+(optional) flip button order
+when in fullscreen mode
+macos layout
+
 /*-------------------------------------------------------------------------------------*/
-/* baseline */
+
+/* baseline modifications */
 
 #navigator-toolbox {
   background: var(--toolbar-bgcolor) !important;
@@ -33,6 +44,7 @@ toolbox#navigator-toolbox > toolbar#nav-bar.browser-toolbar{ animation: none; }
 
 
 /*--------------------------------------------------------------------------------------*/
+
 /* to return the title bar buttons */
 
 :root[tabsintitlebar] .titlebar-buttonbox{
@@ -69,7 +81,8 @@ toolbox#navigator-toolbox > toolbar#nav-bar.browser-toolbar{ animation: none; }
 
 
 /*--------------------------------------------------------------------------------------*/
-/* macos */
+
+/* macos layout */
 
 @media (-moz-os-version: macos), (-moz-platform: macos) {
     #nav-bar {

--- a/chrome/window-controls.css
+++ b/chrome/window-controls.css
@@ -1,0 +1,73 @@
+@namespace xul url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
+
+#navigator-toolbox {
+  background: var(--lumina-bg-color-primary) !important;
+}
+#TabsToolbar {
+  display: none !important;
+} #titlebar {
+  display: initial !important;
+} #titlebar {
+    order: 2;
+    -moz-appearance: none !important;
+    --tabs-navbar-shadow-size: 0px;
+    --uc-menubar-vertical-overlap: 19px;
+}
+
+/* some code related code blocks */
+
+#navigator-toolbox > div{ display: contents }
+
+.global-notificationbox, #tab-notification-deck{order: 2;}
+
+#TabsToolbar .titlebar-spacer{ display: none; }
+
+#navigator-toolbox::after{ display: none !important; }
+
+toolbox#navigator-toolbox > toolbar#nav-bar.browser-toolbar{ animation: none; }
+
+#navigator-toolbox:hover #TabsToolbar{ animation: slidein ease-out 48ms 1; }
+
+#navigator-toolbox:not(:-moz-lwtheme){ background-color: -moz-dialog; }
+
+/*-----------------------------------------*/
+/*--to return the title bar buttons--*/
+/*-----------------------------------------*/
+
+:root[tabsintitlebar] .titlebar-buttonbox{
+    position: fixed !important;
+    display: flex !important;
+    z-index: 2 !important;
+    top: 4.2px !important;
+    right: 2px !important;
+    /* left instead of right, if you want it on left side */
+}
+
+/* adjust nav bar margin for fixed button */
+#nav-bar {
+    margin-right: 96px;
+} /* margin-left if you have it on left side*/
+
+/* 30px total button size to match toolbar buttons. */
+@media (-moz-platform: windows) {
+    .titlebar-buttonbox .titlebar-button {
+        padding: 11px 11px !important;
+    }
+}
+
+/* (optional) flip button order
+.titlebar-buttonbox-container{ direction: rtl; } */
+
+/* when in fullscreen mode, and the navigation bar isnt hovered, workaround for fixed title bar buttons */
+
+:root[inFullscreen="true"] #navigator-toolbox:not(:hover) .titlebar-buttonbox {
+    display: none !important;
+}
+
+/* when in fullscreen mode, and the navigation bar isnt hovered, match the themes rounded corners */
+
+@media not (-moz-bool-pref: "ultima.xstyle.squared") {
+    :root[inFullscreen="true"] #navigator-toolbox:not(:hover) + #browser {
+        padding-top: 5px !important;
+    }
+}

--- a/chrome/window-controls.css
+++ b/chrome/window-controls.css
@@ -20,7 +20,7 @@ macos layout
     --wc-top: 4.2px;
     --wc-left: 3px;
     --wc-right: 2px;
-    --navbar-margin: 98px;
+    --navbar-margin: 103px;
     --mb-height: 20px;
 }
 

--- a/chrome/window-controls.css
+++ b/chrome/window-controls.css
@@ -3,15 +3,15 @@
 #navigator-toolbox {
   background: var(--toolbar-bgcolor) !important;
 }
-#TabsToolbar {
-  display: none !important;
-} #titlebar {
-  display: initial !important;
-} #titlebar {
+
+#TabsToolbar { display: none !important; }
+
+#titlebar { display: initial !important; }
+
+#titlebar {
     order: 2;
     -moz-appearance: none !important;
     --tabs-navbar-shadow-size: 0px;
-    --uc-menubar-vertical-overlap: 19px;
 }
 
 /* some code related code blocks */
@@ -30,23 +30,23 @@ toolbox#navigator-toolbox > toolbar#nav-bar.browser-toolbar{ animation: none; }
 
 #navigator-toolbox:not(:-moz-lwtheme){ background-color: -moz-dialog; }
 
-/*-----------------------------------------*/
-/*--to return the title bar buttons--*/
-/*-----------------------------------------*/
+/*--------------------------------------------------------------------------------------*/
+/* to return the title bar buttons */
 
 :root[tabsintitlebar] .titlebar-buttonbox{
     position: fixed !important;
     display: flex !important;
     z-index: 2 !important;
     top: 4.2px !important;
-    right: 2px !important;
-    /* left instead of right, if you want it on left side */
+    right: 2px !important; /* or use 'left' to simulate macos positioning */
 }
 
-/* adjust nav bar margin for fixed button */
+/* to simulate toolbar buttons size and positioning, while keeping the window controls to the far end of the bar */
+
+/* adjust nav bar margin */
 #nav-bar {
-    margin-right: 98px;
-} /* margin-left if you have it on left side*/
+    margin-right: 98px; /* margin-left if you have it on left side*/
+} 
 
 /* 30px total button size to match toolbar buttons. */
 @media (-moz-platform: windows) {
@@ -63,12 +63,4 @@ toolbox#navigator-toolbox > toolbar#nav-bar.browser-toolbar{ animation: none; }
 
 :root[inFullscreen="true"] #navigator-toolbox:not(:hover) .titlebar-buttonbox {
     display: none !important;
-}
-
-/* when in fullscreen mode, and the navigation bar isnt hovered, match the themes rounded corners */
-
-@media not (-moz-bool-pref: "ultima.xstyle.squared") {
-    :root[inFullscreen="true"] #navigator-toolbox:not(:hover) + #browser {
-        padding-top: 5px !important;
-    }
 }

--- a/chrome/window-controls.css
+++ b/chrome/window-controls.css
@@ -1,5 +1,8 @@
 @namespace xul url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
+/*-------------------------------------------------------------------------------------*/
+/* baseline */
+
 #navigator-toolbox {
   background: var(--toolbar-bgcolor) !important;
 }
@@ -14,8 +17,6 @@
     --tabs-navbar-shadow-size: 0px;
 }
 
-/* some code related code blocks */
-
 #navigator-toolbox > div{ display: contents }
 
 .global-notificationbox, #tab-notification-deck{order: 2;}
@@ -29,6 +30,7 @@ toolbox#navigator-toolbox > toolbar#nav-bar.browser-toolbar{ animation: none; }
 #navigator-toolbox:hover #TabsToolbar{ animation: slidein ease-out 48ms 1; }
 
 #navigator-toolbox:not(:-moz-lwtheme){ background-color: -moz-dialog; }
+
 
 /*--------------------------------------------------------------------------------------*/
 /* to return the title bar buttons */
@@ -63,4 +65,24 @@ toolbox#navigator-toolbox > toolbar#nav-bar.browser-toolbar{ animation: none; }
 
 :root[inFullscreen="true"] #navigator-toolbox:not(:hover) .titlebar-buttonbox {
     display: none !important;
+}
+
+
+/*--------------------------------------------------------------------------------------*/
+/* macos */
+
+@media (-moz-os-version: macos), (-moz-platform: macos) {
+    #nav-bar {
+        margin-left: 84px !important;
+        margin-right: 0px !important;
+    }    
+    
+    :root[tabsintitlebar] .titlebar-buttonbox {
+        top: 12px !important;
+        right: unset !important;
+        left: 3px !important;
+    }
+    toolbar {
+        min-height: 0px !important;
+    }
 }


### PR DESCRIPTION
Added `window-controls.css` into the theme directory. This one file solution returns Window Controls to the UI for creators with One-Line Navigation bar themes.

It simulates the look (spacing, border-radius) of toolbar buttons already present on the nav bar, and includes an adaption for when the Browser is in fullscreen mode (nav-bar becomes hidden). This lets potential users of your theme to not have to rely on a [third party extension](https://addons.mozilla.org/en-US/firefox/addon/min-max-close-hub/) to retrieve the functionality of minimizing, maximizing, closing their browser window.

Also includes Mac OS compatibility through media query.

![2024-07-13_15-17](https://github.com/user-attachments/assets/0c09d502-89e8-435a-a87a-3e889d042a11)